### PR TITLE
oci-fetch: Fix wrong oci layout

### DIFF
--- a/lib/schema/descriptor.go
+++ b/lib/schema/descriptor.go
@@ -1,0 +1,21 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+type Descriptor struct {
+	MediaType string `json:"mediaType"`
+	Digest    string `json:"digest"`
+	Size      int    `json:"size"`
+}

--- a/oci-fetch/main.go
+++ b/oci-fetch/main.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -113,7 +112,11 @@ func newWalkFn(parentDir string, tw *tar.Writer) filepath.WalkFunc {
 		if err != nil {
 			return err
 		}
-		h.Name = strings.TrimPrefix(path, parentDir)
+		h.Name, err = filepath.Rel(parentDir, path)
+		if err != nil {
+			return err
+		}
+
 		err = tw.WriteHeader(h)
 		if err != nil {
 			return err


### PR DESCRIPTION
oci fetch is generating a wrong oci layout (doesn't pass `oci-image-tool
validation`) because oci-fetch was writing inside the refs/ dir the manifest
instead of the descriptor.

This patch fixes this doing multiple things:
- write a descriptor inside the refs/ dir
- save the manifest as a blob inside blobs/ dir
- keep the retrieved manifest data (without unmarshall/marshall)
  since this will change the file digests.
- remove leading / in tar entries

This has been tested by temporary uncommenting the docker v2.2 mediaTypes in
`lib/schema/mediatype.go`
