### PR TITLE
fixes go build error cobra.Command.Usage() should be UsageString()

### DIFF
--- a/oci-fetch/main.go
+++ b/oci-fetch/main.go
@@ -58,7 +58,7 @@ func main() {
 
 func runOCIFetch(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
-		cmd.Usage()
+		fmt.Print(cmd.UsageString())
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Build error.. no api `Usage()` `in github.com/spf13/cobra` ...

Signed-off-by: Mike Brown brownwm@us.ibm.com
