### PR TITLE
Fixing panic on layer pull as well as provide mechanism for auth

### DIFF
--- a/lib/fetch.go
+++ b/lib/fetch.go
@@ -103,7 +103,7 @@ func (of *OCIFetcher) Fetch(u *URL, outputDir string) error {
 
 	// download all of the layers into the blobs directory, displaying progress
 	// bars for the user
-	cpp := &progressutil.CopyProgressPrinter{}
+	cpp := progressutil.NewCopyProgressPrinter()
 	layers := removeDuplicateLayers(manifest.Layers)
 
 	var doneChans []chan error

--- a/oci-fetch/main.go
+++ b/oci-fetch/main.go
@@ -30,6 +30,8 @@ import (
 )
 
 var (
+	username                        string
+	password                        string
 	flagDebug                       bool
 	flagInsecureAllowHTTP           bool
 	flagInsecureSkipTLSVerification bool
@@ -43,6 +45,8 @@ var (
 )
 
 func init() {
+	cmdOCIFetch.PersistentFlags().StringVar(&username, "username", "", "username for pull")
+	cmdOCIFetch.PersistentFlags().StringVar(&password, "password", "", "password for pull")
 	cmdOCIFetch.PersistentFlags().BoolVar(&flagDebug, "debug", false, "print out debugging information to stderr")
 	cmdOCIFetch.PersistentFlags().BoolVar(&flagInsecureAllowHTTP, "insecure-allow-http", false, "don't enforce encryption when fetching images")
 	cmdOCIFetch.PersistentFlags().BoolVar(&flagInsecureSkipTLSVerification, "insecure-skip-tls-verification", false, "don't perform TLS certificate verification")
@@ -77,7 +81,7 @@ func runOCIFetch(cmd *cobra.Command, args []string) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	of := lib.NewOCIFetcher("", "", flagInsecureAllowHTTP, flagInsecureSkipTLSVerification, flagDebug)
+	of := lib.NewOCIFetcher(username, password, flagInsecureAllowHTTP, flagInsecureSkipTLSVerification, flagDebug)
 	err = of.Fetch(u, tmpDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)


### PR DESCRIPTION
This fixes the panic on layer pull, as well as adding flags for accepting username and password. Since accepting username and password as a command line argument can be a concern on some systems, a prompt flag is provided to capture them over stdin.

Also happy to break these into separate PRs if you'd prefer.